### PR TITLE
RPC shared state with GRANDPA rialto.

### DIFF
--- a/bin/rialto/node/src/service.rs
+++ b/bin/rialto/node/src/service.rs
@@ -216,6 +216,9 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	let name = config.network.node_name.clone();
 	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
+	
+	let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
+
 
 	let rpc_extensions_builder = {
 		use sc_finality_grandpa::FinalityProofProvider as GrandpaFinalityProofProvider;
@@ -231,7 +234,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 
 		let justification_stream = grandpa_link.justification_stream();
 		let shared_authority_set = grandpa_link.shared_authority_set().clone();
-		let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
+		let shared_voter_state = shared_voter_state.clone();
 
 		let finality_proof_provider =
 			GrandpaFinalityProofProvider::new_for_service(backend, Some(shared_authority_set.clone()));
@@ -349,7 +352,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			network,
 			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
 			prometheus_registry,
-			shared_voter_state: SharedVoterState::empty(),
+			shared_voter_state: shared_voter_state.clone(),
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
 


### PR DESCRIPTION
The current setup does not work, because the state is always empty when queried through RPC.